### PR TITLE
Configure to run as a non-root user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,30 @@
 FROM alpine:3.6
 
-RUN apk update && apk add --no-cache squid incron
-
-COPY squid.conf /etc/squid/squid.conf
-COPY entrypoint.sh /sbin/entrypoint.sh
-RUN chmod 755 /sbin/entrypoint.sh
-
+# Expose port to listen on
 EXPOSE 3128/tcp
 
-CMD ["entrypoint.sh"]
+# Update and add missing packages
+RUN apk update && apk add --no-cache squid incron
+
+# Setup incron to listen on changes to squid config file and reload service
+RUN echo "lockfile_dir = /home/proxy" >> /etc/incron.conf
+RUN echo "/etc/squid/squid.conf IN_MODIFY /usr/sbin/squid -k reconfigure" > /etc/incron.d/squid.conf
+
+# Copy basic squid config and entrypoint script
+COPY squid.conf /etc/squid/squid.conf
+COPY entrypoint.sh /sbin/entrypoint.sh
+
+# Make entrypoint script executable
+RUN chmod 755 /sbin/entrypoint.sh
+
+# Allow squid to write to stdout
+RUN chown squid.squid /dev/stdout
+
+# Add proxy non-privileged user to use
+RUN adduser -G squid -S proxy
+
+# Switch to proxy user
+USER proxy
+
+# Start the service
+CMD ["/sbin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,7 @@
 #!/bin/sh -e
 
-# Configure incron to listen on modifications to Squid Proxy config and reconfigure service
-echo "/etc/squid/squid.conf IN_MODIFY /usr/sbin/squid -k reconfigure" > /etc/incron.d/squid.conf
-
-# Start listener for Squid config file
+# Start incron listener to detect changes to the squid config file
 incrond
-
-# Grant squid user access to stdout to write logs
-chown squid.squid /dev/stdout
 
 # Run the Squid Proxy service
 /usr/sbin/squid -N

--- a/squid.conf
+++ b/squid.conf
@@ -12,14 +12,18 @@ http_access allow all
 # LISTENING PORT
 http_port 3128
 
+# PID file location
+pid_filename /home/proxy/squid.pid
+
 # ADDITIONAL TWEAKS
 cache deny all
 forwarded_for delete
+httpd_suppress_version_string on
 via off
 
 # LOGGING
 logfile_rotate 0
+logformat squid {"logtime":"%tl", response_time":%tr, "src_ip":"%>a", "squid_request_status":"%Ss", "http_status_code":%>Hs, "request_size":%>st, "reply_size":%<st, "http_method":"%rm", "request_url":"%ru", "request_path":"%rp", "squid":"%Sh", "dst_ip":"%<a", "content_type":"%mt"}
 cache_log stdio:/dev/stdout
 access_log stdio:/dev/stdout
 cache_store_log stdio:/dev/stdout
-logformat squid {"logtime":"%tl", response_time":%tr, "src_ip":"%>a", "squid_request_status":"%Ss", "http_status_code":%>Hs, "reply_size_include_header":%<st, "http_method":"%rm", "request_url":"%ru", "user":"%[un", "squid":"%Sh", "dst_ip":"%<a", "content_type":"%mt"}


### PR DESCRIPTION
NOTE: If passing a custom squid config, you must specify the following within the configuration (for incrond to work): `pid_filename /home/proxy/squid.pid`